### PR TITLE
chore(ci): bump GitHub Actions to v6 majors (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -13,12 +13,12 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Validate version metadata


### PR DESCRIPTION
## Summary
Update all GitHub Actions to their v6 majors so workflows run on Node.js 24, ahead of the 2026-06-02 deprecation of Node 20 on the runner.

- `actions/checkout@v4` → `@v6`
- `actions/setup-node@v4` → `@v6`
- `actions/setup-python@v5` → `@v6`

Also bumps `ci.yml` `node-version` from `20` to `24` to match `publish-npm.yml` and the runtime the shim launcher targets.

## Risk
Low. CI on this PR exercises the new versions end-to-end before merge.